### PR TITLE
persist the frameworkID

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "chef/centos-7.0"
     config.ssh.forward_agent = true
     config.vm.network "forwarded_port", guest: 5050, host: 5050
+    config.vm.network "forwarded_port", guest: 5051, host: 5051
+    config.vm.network "forwarded_port", guest: 2181, host: 2181
     config.vm.network "forwarded_port", guest: 4200, host: 4200
     config.vm.provision "shell", path: "vagrant_up.sh"
 end

--- a/src/main/java/io/crate/frameworks/mesos/CrateState.java
+++ b/src/main/java/io/crate/frameworks/mesos/CrateState.java
@@ -1,40 +1,61 @@
 package io.crate.frameworks.mesos;
 
-import org.apache.mesos.Protos;
-import org.apache.mesos.SchedulerDriver;
+import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
 import org.apache.mesos.state.Variable;
 import org.apache.mesos.state.ZooKeeperState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 public class CrateState {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CrateState.class);
 
     private final ZooKeeperState zkState;
-    private Variable lastState = null;
+
+    private static final String INSTANCES = "crate_instances";
+    private static final String FRAMEWORK_ID = "framework_id";
+
+    private final Future<Variable> zkInstancesFuture;
+    private final Future<Variable> zkFrameworkIDFuture;
+
+    private Variable zkInstances = null;
+    private Variable zkFrameworkID = null;
 
     public CrateState(ZooKeeperState zkState) {
         this.zkState = zkState;
+        LOGGER.info("retrieving state from zk");
+        zkInstancesFuture = zkState.fetch(INSTANCES);
+        zkFrameworkIDFuture = zkState.fetch(FRAMEWORK_ID);
     }
 
-    public CrateInstances retrieveState() {
-        LOGGER.info("retrieving state from zk");
+    public CrateInstances crateInstances() {
+        if (zkInstances == null) {
+            try {
+                zkInstances = zkInstancesFuture.get();
+            } catch (ExecutionException | InterruptedException e) {
+                LOGGER.error("Couldn't retrieve crateInstances from ZK");
+                return new CrateInstances();
+            }
+        }
         try {
-            lastState = zkState.fetch("crate_instances").get();
-            LOGGER.info("retrieved {} bytes from zk", lastState.value().length);
-            CrateInstances crateInstances = CrateInstances.fromStream(lastState.value());
+            CrateInstances crateInstances = CrateInstances.fromStream(zkInstances.value());
             LOGGER.info("received crateInstances from zk... got {} instances", crateInstances.size());
-
             return crateInstances;
-
-        } catch (Exception e) {
-            LOGGER.error("couldn't serialize CrateInstances", e);
+        } catch (IOException e) {
+            LOGGER.error("Couldn't read/serialize crateInstances");
             return new CrateInstances();
         }
+    }
+
+    public void instances(CrateInstances activeOrPendingInstances) {
+        LOGGER.info("updating state with {} instances in zk", activeOrPendingInstances.size());
+        zkState.store(zkInstances.mutate(activeOrPendingInstances.toStream()));
+        LOGGER.info("stored new state");
     }
 
     public int desiredInstances() {
@@ -42,10 +63,29 @@ public class CrateState {
         return 1;
     }
 
+    public void frameworkID(String frameworkId) {
+        zkState.store(zkFrameworkID.mutate(frameworkId.getBytes(Charsets.UTF_8)));
+        LOGGER.info("Stored frameworkID: {}", frameworkId);
+    }
 
-    public void storeState(CrateInstances activeOrPendingInstances) {
-        LOGGER.info("updating state with {} instances in zk", activeOrPendingInstances.size());
-        zkState.store(lastState.mutate(activeOrPendingInstances.toStream()));
-        LOGGER.info("stored new state");
+    public Optional<String> frameworkId() {
+        if (zkFrameworkID == null) {
+            try {
+                zkFrameworkID = zkFrameworkIDFuture.get();
+            } catch (ExecutionException | InterruptedException e) {
+                LOGGER.error("error retrieving framework_id from zk", e);
+                return Optional.absent();
+            }
+        }
+
+        if (zkFrameworkID.value().length == 0) {
+            LOGGER.info("ZK didn't have a frameworkID. Will get a new one");
+            return Optional.absent();
+        }
+
+
+        String id = new String(zkFrameworkID.value(), Charsets.UTF_8);
+        LOGGER.info("Re-using frameworkID {}", id);
+        return Optional.of(id);
     }
 }


### PR DESCRIPTION
In case the master or framework stops and starts again it will have to re-use
the previous frameworkID. Otherwise slaves won't recognize the (new) ID and
the already running tasks cannot be assigned correctly to the framework.
