### PR TITLE
only update configured version if status updates are received

### DIFF
--- a/src/main/java/io/crate/frameworks/mesos/CrateInstances.java
+++ b/src/main/java/io/crate/frameworks/mesos/CrateInstances.java
@@ -1,5 +1,8 @@
 package io.crate.frameworks.mesos;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
 import java.io.Serializable;
 import java.util.*;
 
@@ -66,4 +69,12 @@ public class CrateInstances implements Serializable, Iterable<CrateInstance> {
         return instances.iterator();
     }
 
+    public CrateInstance byTaskId(final String taskId) {
+        return Iterables.find(this, new Predicate<CrateInstance>() {
+            @Override
+            public boolean apply(CrateInstance input) {
+                return input.taskId().equals(taskId);
+            }
+        });
+    }
 }

--- a/src/test/java/io/crate/frameworks/mesos/CrateSchedulerTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/CrateSchedulerTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static io.crate.frameworks.mesos.SaneProtos.taskID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
@@ -97,6 +98,10 @@ public class CrateSchedulerTest {
 
         CrateScheduler crateScheduler = initScheduler(configuration, "xx");
         crateScheduler.reconcileTasks(driver);
+        crateScheduler.statusUpdate(driver,
+                Protos.TaskStatus.newBuilder()
+                        .setTaskId(taskID("1"))
+                        .setState(Protos.TaskState.TASK_RUNNING).build());
 
         assertThat(configuration.version(), is("0.47.7"));
     }


### PR DESCRIPTION
Scenario:

start framework with a version that doesn't exist and scale to 1 instance.

```
-> state is saved with that version
```

stop/restart framework with valid version

```
-> previously: new valid version was overwritten with
```

   invalid from "running" instance

```
-> now: will wait for status update (which will be task
```

   lost) and therefore not overwrite the valid version
