### PR TITLE
store http and transport port in Zookeeper state

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ CHANGES for Crate Mesos Framework
 Unreleased
 ==========
 
+  - Store http and transport port in Zookeeper state, so they persist in
+    a framework lifetime when using dynamically allocated ports with Marathon
+
 2015/08/08 0.1.0
 ================
 

--- a/src/main/java/io/crate/frameworks/mesos/CrateExecutableInfo.java
+++ b/src/main/java/io/crate/frameworks/mesos/CrateExecutableInfo.java
@@ -45,14 +45,20 @@ public class CrateExecutableInfo implements Serializable {
     private final String execId;
     private final Configuration configuration;
     private final List<Attribute> attributes;
+    private final int httpPort;
+    private final int transportPort;
 
     public CrateExecutableInfo(Configuration configuration,
                                String hostname,
-                               CrateInstances crateInstances,
+                               int httpPort,
+                               int transportPort,
+                               String unicastHosts,
                                List<Attribute> attributes) {
         this.execId = UUID.randomUUID().toString();
-        this.hostname = hostname;
         this.configuration = configuration;
+        this.hostname = hostname;
+        this.httpPort = httpPort;
+        this.transportPort = transportPort;
         this.attributes = attributes;
         this.downloadURIs = asList(
                 URI.create(configuration.versionIsDownloadURL() ?
@@ -60,7 +66,7 @@ public class CrateExecutableInfo implements Serializable {
                         String.format("%s/crate-%s.tar.gz", CDN_URL, configuration.version))
         );
         this.nodeNode = String.format("%s-%s", configuration.clusterName, execId);
-        this.unicastHosts = crateInstances.unicastHosts();
+        this.unicastHosts = unicastHosts;
     }
 
     public String nodeName() {
@@ -68,7 +74,7 @@ public class CrateExecutableInfo implements Serializable {
     }
 
     public int transportPort() {
-        return configuration.transportPort;
+        return transportPort;
     }
 
     public List<String> arguments() {
@@ -77,8 +83,8 @@ public class CrateExecutableInfo implements Serializable {
                 "-p",
                 "crate.pid",
                 String.format("-Des.cluster.name=%s", configuration.clusterName),
-                String.format("-Des.http.port=%d", configuration.httpPort),
-                String.format("-Des.transport.tcp.port=%d", configuration.transportPort),
+                String.format("-Des.http.port=%d", httpPort),
+                String.format("-Des.transport.tcp.port=%d", transportPort),
                 String.format("-Des.node.name=%s", nodeNode),
                 String.format("-Des.discovery.zen.ping.multicast.enabled=%s", "false"),
                 String.format("-Des.discovery.zen.ping.unicast.hosts=%s", unicastHosts)
@@ -109,7 +115,7 @@ public class CrateExecutableInfo implements Serializable {
         );
     }
 
-    public Integer httpPort() { return configuration.httpPort; }
+    public Integer httpPort() { return httpPort; }
 
     public List<URI> uris() {
         return downloadURIs;

--- a/src/main/java/io/crate/frameworks/mesos/CrateInstance.java
+++ b/src/main/java/io/crate/frameworks/mesos/CrateInstance.java
@@ -28,6 +28,7 @@ public class CrateInstance implements Serializable {
     private final String taskId;
     private final String hostname;
     private final String version;
+    private final int httpPort;
     private final int transportPort;
     private final String executorID;
     private final String slaveID;
@@ -39,11 +40,12 @@ public class CrateInstance implements Serializable {
         RUNNING
     }
 
-    public CrateInstance(String hostname, String taskId, String version, int transportPort,
+    public CrateInstance(String hostname, String taskId, String version, int httpPort, int transportPort,
                          String executorID, String slaveID) {
         this.taskId = taskId;
         this.hostname = hostname;
         this.version = version;
+        this.httpPort = httpPort;
         this.transportPort = transportPort;
         this.executorID = executorID;
         this.slaveID = slaveID;
@@ -75,6 +77,10 @@ public class CrateInstance implements Serializable {
         return version;
     }
 
+    public Integer httpPort() {
+        return httpPort;
+    }
+
     public int transportPort() {
         return transportPort;
     }
@@ -89,6 +95,7 @@ public class CrateInstance implements Serializable {
                 "taskId='" + taskId + '\'' +
                 ", hostname='" + hostname + '\'' +
                 ", version='" + version + '\'' +
+                ", httpPort=" + httpPort +
                 ", transportPort=" + transportPort +
                 ", state=" + state +
                 '}';

--- a/src/main/java/io/crate/frameworks/mesos/CrateState.java
+++ b/src/main/java/io/crate/frameworks/mesos/CrateState.java
@@ -38,6 +38,9 @@ public class CrateState implements Serializable {
     private HashMap<String, List<String>> excludedSlaves = new HashMap<>();
     private Set<String> slavesWithInstance = new HashSet<>();
 
+    private int httpPort = 0;
+    private int transportPort = 0;
+
     private static final long serialVersionUID = 1L;
 
     public static final int UNDEFINED_DESIRED_INSTANCES = -1;
@@ -49,8 +52,7 @@ public class CrateState implements Serializable {
         }
         ByteArrayInputStream in = new ByteArrayInputStream(value);
         try (ObjectInputStream objectInputStream = new ObjectInputStream(in)) {
-            CrateState state = (CrateState) objectInputStream.readObject();
-            return state;
+            return (CrateState) objectInputStream.readObject();
         } catch (ClassNotFoundException e) {
             LOGGER.error("Could not deserialize ClusterState:", e);
         }
@@ -89,6 +91,22 @@ public class CrateState implements Serializable {
 
     public Optional<String> frameworkId() {
         return Optional.fromNullable(frameworkId);
+    }
+
+    public void httpPort(int httpPort) {
+        this.httpPort = httpPort;
+    }
+
+    public int httpPort() {
+        return this.httpPort;
+    }
+
+    public void transportPort(int transportPort) {
+        this.transportPort = transportPort;
+    }
+
+    public int transportPort() {
+        return this.transportPort;
     }
 
     public int missingInstances() {

--- a/src/main/java/io/crate/frameworks/mesos/api/CrateRestResource.java
+++ b/src/main/java/io/crate/frameworks/mesos/api/CrateRestResource.java
@@ -72,6 +72,8 @@ public class CrateRestResource {
     public Response clusterIndex(@Context UriInfo uriInfo) {
         final int desired = store.state().desiredInstances().getValue();
         final int running = store.state().crateInstances().size();
+        final int httpPort = store.state().httpPort();
+        final int transportPort = store.state().transportPort();
         final HashMap<String, List<String>> excluded = store.state().excludedSlaves();
         return Response.ok().entity(new GenericAPIResponse() {
             @Override
@@ -90,7 +92,8 @@ public class CrateRestResource {
                             {
                                 put("version", conf.version);
                                 put("name", conf.clusterName);
-                                put("httpPort", conf.httpPort);
+                                put("httpPort", httpPort);
+                                put("transportPort", transportPort);
                                 put("nodeCount", conf.nodeCount);
                             }
                         });

--- a/src/main/java/io/crate/frameworks/mesos/config/Resources.java
+++ b/src/main/java/io/crate/frameworks/mesos/config/Resources.java
@@ -23,6 +23,7 @@ package io.crate.frameworks.mesos.config;
 
 import com.google.common.base.Function;
 import com.google.common.collect.*;
+import io.crate.frameworks.mesos.CrateState;
 import org.apache.mesos.Protos;
 
 import java.util.List;
@@ -39,25 +40,24 @@ public class Resources {
     };
 
     @SuppressWarnings("RedundantIfStatement")
-    public static boolean matches(List<Protos.Resource> offeredResources, Configuration configuration) {
+    public static boolean matches(List<Protos.Resource> offeredResources, Configuration configuration, CrateState state) {
         ImmutableListMultimap<String, Protos.Resource> resourceMap = Multimaps.index(offeredResources, RESOURCE_NAME);
 
-        Protos.Resource cpus1 = getOnlyElement(resourceMap.get("cpus"));
-        if (cpus1.getScalar().getValue() < configuration.resCpus) {
+        Protos.Resource cpus = getOnlyElement(resourceMap.get("cpus"));
+        if (cpus.getScalar().getValue() < configuration.resCpus) {
             return false;
         }
 
         Protos.Resource mem = getOnlyElement(resourceMap.get("mem"));
-
         if (mem.getScalar().getValue() < configuration.resMemory) {
             return false;
         }
 
         ImmutableList<Protos.Resource> ports = resourceMap.get("ports");
-        if(!isPortInRange(configuration.httpPort, ports)) {
+        if (!isPortInRange(state.httpPort(), ports)) {
             return false;
         }
-        if(!isPortInRange(configuration.transportPort, ports)) {
+        if (!isPortInRange(state.transportPort(), ports)) {
             return false;
         }
 

--- a/src/test/java/io/crate/frameworks/mesos/CrateInstancesTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/CrateInstancesTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.*;
 public class CrateInstancesTest {
 
     private static CrateInstance newInstance(String hostname, String taskId) {
-        return new CrateInstance(hostname, taskId, "0.47.0", 4300, "exec-1", "slave-1");
+        return new CrateInstance(hostname, taskId, "0.47.0", 4200, 4300, "exec-1", "slave-1");
     }
 
     @Test

--- a/src/test/java/io/crate/frameworks/mesos/CrateSchedulerTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/CrateSchedulerTest.java
@@ -72,7 +72,7 @@ public class CrateSchedulerTest {
     @Test
     public void testThatRegisteredWithInstancesRunning() throws Exception {
         CrateInstances instances = new CrateInstances();
-        instances.addInstance(new CrateInstance("foo", "1", "0.47.0", 4300, "exec-1", "slave-1"));
+        instances.addInstance(new CrateInstance("foo", "1", "0.47.0", 4200, 4300, "exec-1", "slave-1"));
         state.desiredInstances(0);
         state.instances(instances);
 
@@ -114,7 +114,7 @@ public class CrateSchedulerTest {
         Protos.TaskID task = taskID("1");
         // configured version should be changed to the version of the running instance
         CrateInstances instances = new CrateInstances();
-        instances.addInstance(new CrateInstance("host1", task.getValue(), "0.47.7", 4300, "exec1", "slave1"));
+        instances.addInstance(new CrateInstance("host1", task.getValue(), "0.47.7", 4200, 4300, "exec1", "slave1"));
         state.instances(instances);
         state.desiredInstances(5);
 

--- a/src/test/java/io/crate/frameworks/mesos/CrateStateTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/CrateStateTest.java
@@ -49,8 +49,8 @@ public class CrateStateTest {
     public void testSerializeCrateStateWithInstances() throws Throwable {
         CrateState state = new CrateState();
         CrateInstances cluster = new CrateInstances();
-        cluster.addInstance(new CrateInstance("127.0.0.1", "1", "0.47.0", 4300, "exec-1", "slave-1"));
-        cluster.addInstance(new CrateInstance("127.0.0.2", "2", "0.47.0", 4300, "exec-1", "slave-1"));
+        cluster.addInstance(new CrateInstance("127.0.0.1", "1", "0.47.0", 4200, 4300, "exec-1", "slave-1"));
+        cluster.addInstance(new CrateInstance("127.0.0.2", "2", "0.47.0", 4200, 4300, "exec-1", "slave-1"));
         cluster.setToRunning("1", "id-1");
         state.instances(cluster);
 

--- a/src/test/java/io/crate/frameworks/mesos/api/CrateRestResourceTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/api/CrateRestResourceTest.java
@@ -45,7 +45,10 @@ public class CrateRestResourceTest {
         configuration.version("0.48.0");
         PersistentStateStore mockedStore = mock(PersistentStateStore.class);
         CrateState state = new CrateState();
-        CrateInstance crate1 = new CrateInstance("crate1", "task-1", "0.48.0", 44300, "exec-1", "slave-1");
+        state.httpPort(44200);
+        state.transportPort(44300);
+        CrateInstance crate1 = new CrateInstance("crate1", "task-1", "0.48.0",
+                state.httpPort(), state.transportPort(), "exec-1", "slave-1");
         state.crateInstances().addInstance(crate1);
         when(mockedStore.state()).thenReturn(state);
         resource = new CrateRestResource(mockedStore, configuration);
@@ -68,7 +71,8 @@ public class CrateRestResourceTest {
             {
                 put("version", "0.48.0");
                 put("name", "crate");
-                put("httpPort", 4200);
+                put("httpPort", 44200);
+                put("transportPort", 44300);
                 put("nodeCount", 0);
             }
         });

--- a/src/test/java/io/crate/frameworks/mesos/config/ResourcesTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/config/ResourcesTest.java
@@ -1,5 +1,6 @@
 package io.crate.frameworks.mesos.config;
 
+import io.crate.frameworks.mesos.CrateState;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,6 +15,7 @@ import static org.hamcrest.core.Is.is;
 public class ResourcesTest {
 
     private Configuration configuration;
+    private CrateState state;
 
     @Before
     public void setUp() throws Exception {
@@ -22,27 +24,30 @@ public class ResourcesTest {
         configuration.resMemory = 1024d * 8;
         configuration.resHeap = 1024d * 4;
         configuration.resDisk = 1024d * 20;
-        configuration.httpPort = 4200;
+
+        state = new CrateState();
+        state.httpPort(4200);
+        state.transportPort(4300);
     }
 
     @Test
     public void testMatchesWithOfferThatHasToFewCpus() throws Exception {
-        assertThat(Resources.matches(Arrays.asList(cpus(1), mem(20_000)), configuration), is(false));
+        assertThat(Resources.matches(Arrays.asList(cpus(1), mem(20_000)), configuration, state), is(false));
     }
 
     @Test
     public void testMatchesWithOfferThatHasNotEnoughMemory() throws Exception {
-        assertThat(Resources.matches(Arrays.asList(cpus(4), mem(512)), configuration), is(false));
+        assertThat(Resources.matches(Arrays.asList(cpus(4), mem(512)), configuration, state), is(false));
     }
 
     @Test
     public void testMatchesWithOfferThatHasNoRequestedPorts() throws Exception {
-        assertThat(Resources.matches(Arrays.asList(cpus(4), mem(512), ports(3000, 4000)), configuration), is(false));
+        assertThat(Resources.matches(Arrays.asList(cpus(4), mem(512), ports(3000, 4000)), configuration, state), is(false));
     }
 
     @Test
     public void testMatchesWithOfferThatHasEnough() throws Exception {
-        assertThat(Resources.matches(Arrays.asList(cpus(4), mem(20_000), ports(4000, 5000)), configuration), is(true));
+        assertThat(Resources.matches(Arrays.asList(cpus(4), mem(20_000), ports(4000, 5000)), configuration, state), is(true));
     }
 
     @Test
@@ -51,6 +56,6 @@ public class ResourcesTest {
                 cpus(4),
                 mem(20_000),
                 ports(4200, 4200),
-                ports(4300, 4300)), configuration), is(true));
+                ports(4300, 4300)), configuration, state), is(true));
     }
 }


### PR DESCRIPTION
so they persist in a framework lifetime
when using dynamically allocated ports in a Marathon configuration

see also: https://github.com/mesosphere/universe/compare/version-1.x...crate:crate-dynamic-ports?expand=1