### PR TITLE
Fixed nodeCount parameter

### DIFF
--- a/src/main/java/io/crate/frameworks/mesos/CrateScheduler.java
+++ b/src/main/java/io/crate/frameworks/mesos/CrateScheduler.java
@@ -150,6 +150,7 @@ public class CrateScheduler implements Scheduler {
 
         }
 
+        state.desiredInstances(configuration.nodeCount);
     }
 
     @Override

--- a/src/test/java/io/crate/frameworks/mesos/CrateSchedulerTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/CrateSchedulerTest.java
@@ -82,6 +82,14 @@ public class CrateSchedulerTest {
     }
 
     @Test
+    public void testNodeCountParameter() throws Exception {
+        Configuration conf = new Configuration();
+        conf.nodeCount = 2;
+        CrateScheduler crateScheduler = initScheduler(conf, "xx");
+        assertThat(state.desiredInstances().getValue(), is(2));
+    }
+
+    @Test
     public void testResourceOffersDoesNotSpawnTooManyTasks() throws Exception {
         CrateInstances instances = new CrateInstances();
 


### PR DESCRIPTION
With this fix, you can create crate cluster with the number of "--crate-node-count" parameter nodes when you are scheduling crate-mesos-framework