### PR TITLE
fix minimesos test bug

### DIFF
--- a/src/test/java/io/crate/frameworks/mesos/integration/BaseIntegrationTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/integration/BaseIntegrationTest.java
@@ -100,7 +100,7 @@ public class BaseIntegrationTest {
             @Override
             public Boolean call() throws Exception {
                 for (MesosAgent mesosAgent : cluster.getAgents()) {
-                    if (!mesosAgent.getState().getFrameworks().isEmpty()) {
+                    if (mesosAgent.getState().getFramework("crate-dev").isActive()) {
                         try {
                             int status = Unirest.head(
                                     String.format("http://%s:%d/cluster", mesosAgent.getIpAddress(), API_PORT)

--- a/src/test/java/io/crate/frameworks/mesos/integration/BaseIntegrationTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/integration/BaseIntegrationTest.java
@@ -100,7 +100,8 @@ public class BaseIntegrationTest {
             @Override
             public Boolean call() throws Exception {
                 for (MesosAgent mesosAgent : cluster.getAgents()) {
-                    if (mesosAgent.getState().getFramework("crate-dev").isActive()) {
+                    if (mesosAgent.getState().getFramework("crate-dev") != null &&
+                            mesosAgent.getState().getFramework("crate-dev").isActive()) {
                         try {
                             int status = Unirest.head(
                                     String.format("http://%s:%d/cluster", mesosAgent.getIpAddress(), API_PORT)

--- a/src/test/java/io/crate/frameworks/mesos/integration/BaseIntegrationTest.java
+++ b/src/test/java/io/crate/frameworks/mesos/integration/BaseIntegrationTest.java
@@ -3,7 +3,6 @@ package io.crate.frameworks.mesos.integration;
 import com.containersol.minimesos.cluster.MesosAgent;
 import com.containersol.minimesos.cluster.MesosCluster;
 import com.containersol.minimesos.junit.MesosClusterTestRule;
-import com.containersol.minimesos.state.Framework;
 import com.jayway.awaitility.Awaitility;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
@@ -35,7 +34,7 @@ public class BaseIntegrationTest {
     private static final int HTTP_PORT = 4200;
     private static final int TRANSPORT_PORT = 4300;
     private static final int API_PORT = 4242;
-    private static final int WAIT_TIMEOUT_SECONDS = 190;
+    private static final int WAIT_TIMEOUT_SECONDS = 90;
 
     @ClassRule
     public static MesosClusterTestRule testRule =
@@ -69,8 +68,6 @@ public class BaseIntegrationTest {
             appJson = replaceToken(appJson, "ZOOKEEPER", cluster.getZooKeeper().getIpAddress());
             appJson = replaceToken(appJson, "MESOS_MASTER", cluster.getZooKeeper().getFormattedZKAddress());
             appJson = replaceToken(appJson, "CRATE_VERSION", crateVersion());
-
-            System.out.println("appSJON : " + appJson);
             return appJson;
         }
     }
@@ -103,12 +100,6 @@ public class BaseIntegrationTest {
             @Override
             public Boolean call() throws Exception {
                 for (MesosAgent mesosAgent : cluster.getAgents()) {
-
-                    //just for testing, will be deleted then
-                    for(Framework fw : mesosAgent.getState().getFrameworks()){
-                        System.out.println(fw.getName());
-                    }
-
                     try {
                         int status = Unirest.head(
                                 String.format("http://%s:%d/cluster", mesosAgent.getIpAddress(), API_PORT)
@@ -120,7 +111,6 @@ public class BaseIntegrationTest {
                     } catch (UnirestException e) {
                         //ignore
                     }
-                    //}
                 }
                 return false;
             }

--- a/src/test/resources/app.json
+++ b/src/test/resources/app.json
@@ -30,7 +30,7 @@
             "cache": false
         }
     ],
-    "cmd": "env && $(pwd)/jre/bin/java $JAVA_OPTS -jar $(pwd)/${CRATE_MESOS_FRAMEWORK} --zookeeper ${ZOOKEEPER}:2181 --api-port $PORT0 --crate-cluster-name $CRATE_CLUSTER_NAME --crate-version ${CRATE_VERSION} --crate-http-port $CRATE_HTTP_PORT --crate-transport-port $CRATE_TRANSPORT_PORT --resource-cpus 0.25 --resource-memory 512",
+    "cmd": "env && $(pwd)/jre/bin/java $JAVA_OPTS -jar $(pwd)/${CRATE_MESOS_FRAMEWORK} --zookeeper ${ZOOKEEPER}:2181 --api-port $PORT0 --crate-cluster-name $CRATE_CLUSTER_NAME --crate-version ${CRATE_VERSION} --crate-http-port $CRATE_HTTP_PORT --crate-transport-port $CRATE_TRANSPORT_PORT --resource-cpus 0.25 --resource-memory 512 --framework-user root",
     "healthChecks": [
         {
             "protocol": "HTTP",


### PR DESCRIPTION
``mesosAgent.getState().getFrameworks().isEmpty()`` can return ``true`` if there is only marathon running, since marathon is also a framework. But what we are looking for is crate framework, that is why this check is fixed.